### PR TITLE
chore: move monitored demo servers to openvoiceos.pt domain

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -3,55 +3,31 @@ owner: TigreGotico # Your GitHub organization or username, where this repository
 repo: public-servers # The name of this repository
 
 sites:
-  - name: OpenData - Metrics API
-    url: https://metrics.tigregotico.pt/status
-  - name: OpenData - Dashboard
-    url: https://opendata.tigregotico.pt
   - name: TTS - NOS
-    url: https://nos.tigregotico.pt/status
+    url: https://nos.openvoiceos.pt/status
   - name: TTS - Matxa
-    url: https://matxa.tigregotico.pt/status
+    url: https://matxa.openvoiceos.pt/status
   - name: TTS - Piper
-    url: https://piper.tigregotico.pt/status
+    url: https://piper.openvoiceos.pt/status
   - name: TTS - Mimic
-    url: https://mimic.tigregotico.pt/status
+    url: https://mimic.openvoiceos.pt/status
   - name: TTS - SAM
-    url: https://sam.tigregotico.pt/status
+    url: https://sam.openvoiceos.pt/status
   - name: TTS - OpenTTS (MaryTTS Compatible)
-    url: https://opentts.tigregotico.pt
+    url: https://opentts.openvoiceos.pt
   - name: TTS - Larynx (MaryTTS Compatible)
-    url: https://larynx.tigregotico.pt
+    url: https://larynx.openvoiceos.pt
   - name: TTS - Mimic3 (MaryTTS Compatible)
-    url: https://mimic3.tigregotico.pt
+    url: https://mimic3.openvoiceos.pt
   - name: STT - FasterWhisper (turbo-large-v3)
-    url: https://fasterwhisper.tigregotico.pt/status
+    url: https://fasterwhisper.openvoiceos.pt/status
   - name: STT - Citrinet
-    url: https://citrinet.tigregotico.pt/status
-  - name: STT - Whisper (GPU)
-    url: https://whisper.tigregotico.pt/status
-  - name: STT - MyNorthAI (GPU)
-    url: https://mynorthai.tigregotico.pt/status
-  - name: STT - Nemo (GPU)
-    url: https://nemo.tigregotico.pt/status
-  - name: STT - HiTZ (GPU)
-    url: https://hitz.tigregotico.pt/status
+    url: https://citrinet.openvoiceos.pt/status
   - name: STT - Google Chromium (proxy)
-    url: https://chromium.tigregotico.pt/status
-  - name: Translate - NLLB (GPU)
-    url: https://nllb.tigregotico.pt/status
+    url: https://chromium.openvoiceos.pt/status
   - name: Translate - Google (proxy)
-    url: https://google-translate.tigregotico.pt/status
-  - name: Persona - HiveMind
-    url: https://hivemind-persona.tigregotico.pt/status
-  - name: Benchmark - TTS
-    url: https://tts-bench.tigregotico.pt
-  - name: Benchmark - STT
-    url: https://stt-bench.tigregotico.pt
-  - name: Benchmark - Gitlocalize
-    url: https://gitlocalize-bench.tigregotico.pt
-  - name: Benchmark - Meteocat
-    url: https://meteocat.bench.tigregotico.pt
-    
+    url: https://google-translate.openvoiceos.pt/status
+
 status-website:
   # Add your custom domain name, or remove the `cname` line if you don't have a domain
   # Uncomment the `baseUrl` line if you don't have a custom domain and add your repo name there


### PR DESCRIPTION
## What

Replace all monitored URLs with their **openvoiceos.pt** equivalents. The `tigregotico.pt` DNS was repointed to GitHub Pages, so every monitor in this repo was checking a dead endpoint.

Removed (not redeployed yet — re-add as they come back online): OpenData metrics/dashboard, GPU STT (Whisper, MyNorthAI, Nemo, HiTZ), NLLB translate, HiveMind persona, and the benchmark dashboards.

All 12 remaining endpoints verified answering over HTTPS with fresh Let's Encrypt certs before this PR.

## Model usage

Authored by Claude (Fable 5) as part of the openvoiceos.pt infrastructure migration; endpoint list generated from the live nginx-proxy-manager config and each URL verified with curl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Monitoring Updates**
  * Updated monitoring coverage for text-to-speech, speech-to-text, and translation services using the latest OpenVoiceOS endpoints.
  * Removed several outdated service and benchmark monitors, including legacy OpenData, persona, Whisper, MyNorthAI, Nemo, and HiTZ checks.
  * Retained Chromium and Google Translate monitoring with refreshed URLs for improved accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->