### PR TITLE
chore: swap deprecated demo servers for consolidated fleet

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -3,10 +3,8 @@ owner: TigreGotico # Your GitHub organization or username, where this repository
 repo: public-servers # The name of this repository
 
 sites:
-  - name: TTS - NOS
-    url: https://nos.openvoiceos.pt/status
-  - name: TTS - Matxa
-    url: https://matxa.openvoiceos.pt/status
+  - name: TTS - phoonnx (multilingual, per-request voice)
+    url: https://phoonnx.openvoiceos.pt/status
   - name: TTS - Piper
     url: https://piper.openvoiceos.pt/status
   - name: TTS - Mimic
@@ -21,10 +19,22 @@ sites:
     url: https://mimic3.openvoiceos.pt
   - name: STT - FasterWhisper (turbo-large-v3)
     url: https://fasterwhisper.openvoiceos.pt/status
-  - name: STT - Citrinet
-    url: https://citrinet.openvoiceos.pt/status
   - name: STT - Google Chromium (proxy)
     url: https://chromium.openvoiceos.pt/status
+  - name: STT - Parakeet TDT 0.6b v3 (25 European languages)
+    url: https://parakeet.openvoiceos.pt/status
+  - name: STT - GigaAM v2 (Russian)
+    url: https://gigaam.openvoiceos.pt/status
+  - name: STT - HiTZ Conformer (Basque)
+    url: https://stt-eu.openvoiceos.pt/status
+  - name: STT - Proxecto Nós Conformer (Galician)
+    url: https://stt-gl.openvoiceos.pt/status
+  - name: STT - Conformer (Catalan)
+    url: https://stt-ca.openvoiceos.pt/status
+  - name: STT - Parakeet TDT 0.6b (Portuguese)
+    url: https://stt-pt.openvoiceos.pt/status
+  - name: STT - Vaani FastConformer (Indian languages)
+    url: https://vaani.openvoiceos.pt/status
   - name: Translate - Google (proxy)
     url: https://google-translate.openvoiceos.pt/status
 


### PR DESCRIPTION
Server add/remove per standing arrangement: drops NOS/Matxa/Citrinet (deprecated containers, replaced by phoonnx + onnx-asr fleet), adds phoonnx and the 7 new onnx-asr STT monitors. All endpoints verified live before this PR (transcription and synthesis round-trips, not just /status).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added multilingual per-request text-to-speech monitoring through Phonnx.
  - Added monitoring for Google Chromium speech recognition and multiple language- or model-specific speech-to-text services.

- **Changes**
  - Replaced the previous NOS, Matxa, and Citrinet speech service monitors with updated monitoring coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->