### PR TITLE
chore: add NLLB-200 translation server

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -23,6 +23,8 @@ sites:
     url: https://mimic3.openvoiceos.pt
   - name: STT - Google Chromium (proxy)
     url: https://chromium.openvoiceos.pt/status
+  - name: Translate - NLLB-200 (200 languages)
+    url: https://nllb.openvoiceos.pt/status
   - name: Translate - Google (proxy)
     url: https://google-translate.openvoiceos.pt/status
 


### PR DESCRIPTION
New demo server per standing arrangement: nllb.openvoiceos.pt, NLLB-200 600M int8 covering 200 languages. Verified live (en->gl/eu/ca/ar) before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added uptime monitoring for the NLLB-200 translation service.
  * Service availability can now be checked at its status page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->